### PR TITLE
Enable scrolling in storybook text pages

### DIFF
--- a/storybook.html
+++ b/storybook.html
@@ -205,6 +205,7 @@
       padding: 1rem;
       font-family: Georgia, 'Times New Roman', serif;
       text-align: center;
+      overflow-y: auto;
       transform-style: preserve-3d;
       transition: transform 0.4s ease-in-out;
     }
@@ -316,8 +317,16 @@
     function renderPage() {
       const page = pages[currentPage];
       if (page.type === 'image') {
+        pageDisplay.style.overflowY = 'hidden';
+        pageDisplay.style.alignItems = 'center';
+        pageDisplay.style.justifyContent = 'center';
+        pageDisplay.style.textAlign = 'center';
         pageDisplay.innerHTML = `<img src="${page.src}" alt="" />`;
       } else {
+        pageDisplay.style.overflowY = 'auto';
+        pageDisplay.style.alignItems = 'flex-start';
+        pageDisplay.style.justifyContent = 'flex-start';
+        pageDisplay.style.textAlign = 'left';
         pageDisplay.innerHTML = `<p>${page.content}</p>`;
       }
       prevBtn.disabled = currentPage === 0;


### PR DESCRIPTION
## Summary
- make the page display area scrollable
- adjust `renderPage()` to toggle overflow and alignment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882fd6780408331b96fe6dcb676eaa0